### PR TITLE
docs(master-duel): add Crystron and Crystron Trains deck pages

### DIFF
--- a/Writerside/mi.tree
+++ b/Writerside/mi.tree
@@ -68,6 +68,7 @@
     <toc-element topic="Centurion.md"/>
     <toc-element topic="Voiceless-Voice.md"/>
     <toc-element topic="Maliss-in-underground.md"/>
+    <toc-element topic="Crystron.md"/>
     <toc-element topic="Crystron-trains.md"/>
     <toc-element topic="C05-Aekold-Blacksteel.md"/>
     <toc-element topic="C06-Leilani-Kana.md"/>

--- a/Writerside/mi.tree
+++ b/Writerside/mi.tree
@@ -68,6 +68,7 @@
     <toc-element topic="Centurion.md"/>
     <toc-element topic="Voiceless-Voice.md"/>
     <toc-element topic="Maliss-in-underground.md"/>
+    <toc-element topic="Crystron-trains.md"/>
     <toc-element topic="C05-Aekold-Blacksteel.md"/>
     <toc-element topic="C06-Leilani-Kana.md"/>
     <toc-element topic="Magnimar-lore.md"/>

--- a/Writerside/topics/Master-duel/Crystron-trains.md
+++ b/Writerside/topics/Master-duel/Crystron-trains.md
@@ -118,54 +118,197 @@ Card text on this page checked against the card database on 2026-08-09.
 >> - Detach 1 -> gains 2000 ATK, but only it may attack this turn.
 >> - Attacks up to materials +1 times per Battle Phase. This is your actual kill.
 
-## How the lines run.
+## Combos.
 
-These follow directly from the card text above. They are not copied from a tournament combo guide,
-so treat them as the shape of the deck rather than as an optimised list.
+Every step below was checked against card text. Where a line depends on a card only one of the two
+reference builds plays, it is tagged AMELIA BUILD or YUKINON BUILD. Both are listed in the deck
+variants section further down.
 
-> Opening for rank 10. Do not touch Smiger.
->> 1. Night Train Blue Traveler, discard -> search Revolving Switchyard.
->> 2. Activate Switchyard.
->> 3. Summon any level 10 EARTH machine.
->> 4. Switchyard effect B -> summon Flying Pegasus Railroad Stampede from deck, it becomes level 10.
->> 5. Two level 10 monsters -> Xyz into Gustav Max.
->> 6. REMEMBER: effect B means your opponent takes no battle damage this turn.
+> How to read these.
+>> - Each route is named after the card you OPEN with.
+>> - "Locks Synchro" means Machine Synchro only for the turn. No Xyz, no Link.
+>> - "Locks Machine" means Machine monsters only. Xyz and Link are still legal.
+>> - Decide which lock you are accepting on your FIRST activation. See the lock section above.
 
-> Opening for disruption instead.
->> 1. Crystron Inclusion -> search a Crystron piece.
->> 2. Smiger -> destroy a face-up card you control -> summon a Crystron Tuner from deck.
->> 3. You are now locked to Machine Synchro. No Xyz this turn. Accept it.
->> 4. Set up Synchros, keep Tristaros in hand for your opponent's turn.
->> 5. Smiger from GY -> banish -> add Crystron Cluster.
+### Starter quality.
 
-> The Diagram Token trick.
->> 1. Exceptional Schedule -> add Urgent Schedule.
->> 2. Give your opponent the level 10 / 3000 Diagram Token.
->> 3. They now control more monsters than you, which is Urgent Schedule's activation condition.
->> 4. Urgent Schedule -> summon a level 4 or lower and a level 5 or higher EARTH machine from deck.
->> 5. You cannot attack with non-machines this turn. In this deck that costs you nothing.
+> Starts on its own.
+>> - Crystron Inclusion. The best one. Searches any Crystron, and is itself a Crystron card on the field.
+>> - Exceptional Schedule. Searches, and manufactures Urgent Schedule's activation condition.
+>> - Night Train Blue Traveler. Searches Switchyard, and its GY revive is two bodies.
+>> - Crystron Smiger. One body into a Tuner from deck, but locks you out of Xyz.
 
-> Closing with Babeldecker on turn 2.
->> 1. Your opponent activated something on their turn, so Babeldecker's condition is live.
->> 2. Normal summon Babeldecker without tributing.
->> 3. On summon -> special summon an EARTH machine from hand.
->> 4. Babeldecker alone -> Xyz into a rank 10 EARTH machine.
->> 5. Rank 10 -> Juggernaut Liebe using it as material, transferring materials.
->> 6. Detach for +2000 ATK and multiple attacks.
+> Needs a partner. Do not count these as starters.
+>> - Scrap Recycler. Mills brilliantly but cannot convert a mill into a board by itself. See below.
+>> - Crystron Sulfador. Needs a Crystron CARD already on your field to destroy.
+>> - Crystron Sulfefnir. Needs a second Crystron card in hand to discard.
+>> - Heavy Armored Knight Babeldecker. Needs an EARTH machine in hand, and its Xyz effect needs
+>>   your opponent to have activated something, so it is a turn 2 card.
+>> - Urgent Schedule. Needs your opponent to control more monsters than you.
+>> - Revolving Switchyard. On its own it is one search.
 
-## The current build.
+### Route 1: Crystron Inclusion.
 
-> Roughly what the lists look like.
->> - Trains: 3 Night Train Blue Traveler, 3 Scrap Recycler, 1 Derricrane, 1 Babeldecker, 1 Flying Pegasus.
->> - Spells: 3 Exceptional Schedule, 2 Urgent Schedule, 1 Revolving Switchyard.
->> - Crystron: 3 Inclusion, 2 Sulfador, 2 Sulfefnir, 1 Tristaros, 1 Citree, 1 Smiger, 1 Thystvern, 1 Cluster.
->> - Hand traps and interaction: Ash, Maxx "C", Droll, Mulcharmy Fuwalos, Forbidden Droplet, Triple Tactics Talent.
->> - Extra deck: the five Rail Cannons, Eleskeletus x2, Quariongandrax, plus machine Links.
+The flagship one-card line. Nothing here is optional until step 6.
 
-> Things the deck does NOT play, despite what you might expect.
+> Steps.
+>> 1. Activate Crystron Inclusion -> add Crystron Sulfador from deck.
+>> 2. Sulfador, from hand: target Crystron Inclusion, the Crystron card you control -> destroy it -> summon Sulfador.
+>> 3. ^ Locks Machine. Xyz is still legal. Destroying your own Inclusion is the POINT, not a cost.
+>> 4. Sulfador on summon: send 2 differently named Crystron cards from deck to GY -> send Tristaros and Sulfefnir.
+>> 5. Inclusion is now in your GY. Banish it -> revive Crystron Tristaros.
+>> 6. Sulfador (5) + Tristaros (2) = level 7 -> Synchro summon Crystron Eleskeletus.
+>> 7. Eleskeletus on summon: add 1 Crystron card from GY or banishment -> take Inclusion back for next turn.
+>> 8. Tristaros is in the GY as used material. Banish it -> destroy Eleskeletus -> summon 2 Crystrons from deck.
+>> 9. Eleskeletus destroyed -> its float summons another Crystron from GY or banishment.
+>> 10. You now hold three Crystron bodies and have not used your normal summon.
+
+> Why it works.
+>> - Inclusion is a Continuous SPELL, so it counts as "1 Crystron card you control" for Sulfador.
+>> - Every destruction in this line is your own card, and each one turns on a float or a GY effect.
+
+### Route 2: Night Train Blue Traveler.
+
+> Steps.
+>> 1. Discard Night Train Blue Traveler -> add Revolving Switchyard from deck.
+>> 2. Activate Switchyard. Do NOT use a Switchyard effect yet, you only get one.
+>> 3. Get a second EARTH machine into the GY. Normal summon Scrap Recycler -> send Derricrane to GY.
+>> 4. Blue Traveler from GY: target Derricrane -> summon BOTH. Locks Machine, Xyz still legal.
+>> 5. ^ ONCE PER DUEL. Not per turn. You never get this back.
+>> 6. Two level 10 EARTH machines on the field.
+>> 7. Now spend Switchyard. See the branch below.
+
+> The Switchyard branch, and it is a real decision.
+>> - Going FIRST: use effect B. Summon Flying Pegasus Railroad Stampede from deck, it becomes level 10.
+>> - ^ Three level 10s, which is Gustav Rocket directly. The no-battle-damage clause costs nothing on turn 1.
+>> - ^ AMELIA BUILD ONLY. Yukinon plays no level 4 EARTH machine with 1800+ ATK, so effect B has no target.
+>> - Going SECOND and killing: use effect A instead. Send a card from hand -> add Babeldecker or Derricrane.
+>> - ^ Effect B would switch off your own battle damage for the turn, even after Switchyard leaves the field.
+
+### Route 3: Exceptional Schedule.
+
+The Diagram Token looks like a misplay. It is the activation condition.
+
+> Steps.
+>> 1. Activate Exceptional Schedule -> add Urgent Schedule from deck.
+>> 2. Give your OPPONENT the Diagram Token. Level 10 EARTH machine, 3000/3000.
+>> 3. They now control more monsters than you, which is exactly what Urgent Schedule requires.
+>> 4. Urgent Schedule -> summon 1 level 4 or lower AND 1 level 5 or higher EARTH machine from deck, in defence.
+>> 5. ^ Their effects are NEGATED. A Scrap Recycler summoned this way does NOT mill. Take Blue Traveler and Recycler for bodies, not effects.
+>> 6. You may not attack with non-machines this turn. This deck has none, so it costs nothing.
+
+> Dealing with the token you just gave away.
+>> - You have handed your opponent a 3000 ATK body. Do not leave it there.
+>> - Level 10 + Tristaros (2) = level 12 -> Synchro summon Centur-Ion Legatia.
+>> - Legatia on summon: draw 1, then destroy the monster your opponent controls with the HIGHEST ATK.
+>> - ^ At 3000 the Diagram Token is almost always the highest. You draw a card and take it straight back.
+>> - Legatia is a Machine Synchro, so this line survives even the Synchro lock.
+
+### Route 4: Crystron Smiger. The disruption plan.
+
+Take this line when you want an opponent's-turn board rather than damage.
+
+> Steps.
+>> 1. Normal summon Crystron Smiger.
+>> 2. Target a face-up card you control -> destroy it -> summon 1 Crystron TUNER from deck.
+>> 3. ^ Locks SYNCHRO. Xyz and Link are gone for the turn. This is the trade you are making.
+>> 4. Build Machine Synchros and keep Tristaros in hand for your opponent's turn.
+>> 5. Smiger from GY: banish it -> add 1 Crystron Spell/Trap from deck -> take Crystron Cluster.
+>> 6. Set Cluster. Pass.
+
+> What you are holding for their turn.
+>> - Tristaros in hand: any activation they make turns into a summon from deck plus a Synchro.
+>> - Cluster set: shuffle a Crystron from GY or banishment -> destroy 1 card, or 2 with a Crystron Synchro out.
+>> - Therion "King" Regulus in hand, if you have it, is a free negate. See below.
+
+### Route 5: Heavy Armored Knight Babeldecker. Turn 2 only.
+
+> Steps.
+>> 1. Your opponent activated something on their turn, so Babeldecker's Xyz condition is live.
+>> 2. Normal summon Babeldecker WITHOUT tributing.
+>> 3. On summon -> special summon 1 EARTH machine from your HAND.
+>> 4. Babeldecker alone -> Xyz summon a rank 10 EARTH machine using only itself as material.
+>> 5. Rank 10 -> Juggernaut Liebe, using the rank 10 as material and transferring its materials.
+>> 6. Detach for +2000 ATK. It attacks up to materials +1 times.
+
+### Scrap Recycler is not a starter. Play it as an extender.
+
+> What it actually does.
+>> - Normal or special summoned -> send 1 MACHINE from deck to GY. This has NO once per turn clause.
+>> - ^ So every time you re-summon it, you mill again. That is the engine.
+>> - At 900 ATK it is Clockwork Knight material, and Clockwork Knight can revive it from the GY.
+
+> Why it cannot start alone.
+>> - Milling Sulfador does nothing, because Sulfador needs a Crystron card already on your field.
+>> - Milling Blue Traveler does nothing until a second EARTH machine is in the GY.
+>> - Linking Recycler away fixes that, but then you have no second machine to tribute for Clockwork Knight.
+>> - Recycler plus any of Inclusion, Blue Traveler or Exceptional Schedule is excellent. Recycler alone is a body and a mill.
+
+### Two-card upgrades.
+
+> Inclusion plus Scrap Recycler.
+>> - Run Route 1, but normal summon Recycler first and mill a second Crystron to deepen the GY.
+>> - Recycler is also a spare Link body once its mill is spent.
+
+> Blue Traveler plus Qliphort Genius on the field.
+>> - Blue Traveler's revive summons TWO monsters at the same time.
+>> - Genius: when 2 monsters are special summoned at once to its zones -> add 1 level 5 or higher machine from deck.
+>> - ^ So make Genius BEFORE you use Blue Traveler's GY effect, never after. Ordering is the whole trick.
+
+> Any line plus Therion "King" Regulus.
+>> - Regulus is an EARTH MACHINE, so it fits every lock this deck applies.
+>> - Target any machine in your GY -> summon Regulus from hand and equip that monster to it.
+>> - Then, when your opponent activates anything: send 1 Therion monster card from hand or face-up field -> NEGATE.
+>> - ^ Regulus is itself a Therion monster on your face-up field, so it can send ITSELF. That is a free negate on any board.
+
+### Traps to avoid.
+
+> Derricrane does NOT trigger off Barrage Blast. [YUKINON BUILD]
+>> - Derricrane destroys only when detached "to activate that monster's effect", meaning the Xyz's own effect.
+>> - Detaching it for Gustav Max's burn -> Derricrane destroys a card. Correct.
+>> - Detaching it for Barrage Blast -> nothing. Barrage Blast is not the Xyz monster's effect.
+
+> Do not use Switchyard effect B on a turn you want to attack for game.
+>> - The no-battle-damage clause persists even after Switchyard leaves the field.
+
+> Urgent Schedule negates what it summons.
+>> - Do not plan on the summoned Recycler milling or the summoned Blue Traveler doing anything on summon.
+
+> Blue Traveler's revive is once per DUEL.
+>> - Spending it turn 1 for a rank 10 means it is gone for the rest of the game.
+
+## Deck variants.
+
+Two reference builds. The routes above are tagged where they depend on one of them.
+
+> The shared core. Both builds run all of this.
+>> - 3 Night Train Blue Traveler, 3 Scrap Recycler, 1 Derricrane, 1 Babeldecker, 1 Therion "King" Regulus.
+>> - 3 Exceptional Schedule, 2 Urgent Schedule, 1 Revolving Switchyard.
+>> - 3 Crystron Inclusion, 2+ Sulfador, 2 Sulfefnir, 1 Tristaros, 1 Smiger, 1 Crystron Cluster.
+>> - 3 Ash Blossom, 3 Mulcharmy Fuwalos, 1 Maxx "C", 1 Triple Tactics Talent, 1 Called by the Grave, 1 Crossout Designator.
+>> - Extra: all five Rail Cannons, Eleskeletus, Centur-Ion Legatia, F.A. Dawn Dragster, Infinitrack River Stormer,
+>>   Clockwork Knight, Qliphort Genius, Double Headed Anger Knuckle.
+
+> AMELIA BUILD. 44 cards, Master I, 2026-07-31.
+>> - Adds Flying Pegasus Railroad Stampede, which is the ONLY reason Switchyard effect B is live.
+>> - Adds Crystron Citree and Crystron Thystvern, so a second tuner and a second Crystron searcher.
+>> - Adds Spell Canceller, 2 Droll & Lock Bird, 3 Forbidden Droplet.
+>> - Extra deck adds Crystron Quariongandrax, a second Eleskeletus, Ancient Gear Ballista.
+>> - Plays 44 cards, so it draws its one-ofs less often than the maths on a 40 would suggest.
+
+> YUKINON BUILD. 40 cards, Rating Duels, 2026-07-19.
+>> - Runs 3 Sulfador rather than 2, and adds Foolish Burial to load the GY directly.
+>> - Adds 2 Ghost Belle & Haunted Mansion and 1 Barrage Blast.
+>> - Barrage Blast is searchable off Flying Launcher, which is why a single copy is worth the slot.
+>> - Extra deck swaps toward Cyber Dragon Nova, Cyber Dragon Infinity and AA-ZEUS.
+>> - ^ Nova is 2 level 5 MACHINES, which Sulfador and Sulfefnir both are. That is the Nova into Infinity line.
+>> - NO Flying Pegasus, so Revolving Switchyard is a search card only. Effect B can never resolve.
+
+> Things neither build plays, despite what you might expect.
 >> - Super Express Bullet Train. It needs ALL your monsters to be EARTH machines, and yours are not.
 >> - ^ It also does not search. Its second effect is an End Phase GY effect that recovers a machine.
->> - The older Crystron Tuners. Quan and Rion are too slow. Tristaros and Citree carry the engine.
+>> - Crystron Quan and Crystron Rion. Too slow. Tristaros carries the engine.
+>> - Crystron Ametrix. Neither extra deck has room for it.
 
 ## Weaknesses.
 

--- a/Writerside/topics/Master-duel/Crystron-trains.md
+++ b/Writerside/topics/Master-duel/Crystron-trains.md
@@ -1,126 +1,184 @@
 # Crystron Trains
 
-Crystron is the engine. Trains are the fuel and the win condition.
+Level 10 EARTH machines bolted onto the Crystron engine, for a deck that can actually kill you.
+
+Read [Crystron](Crystron.md) first. This page only covers what the Trains add.
+
+Card text on this page checked against the card database on 2026-08-09.
 
 ## The short version.
 
-> What the deck actually does.
->> - Crystron Synchro summons on your OPPONENT'S turn, not yours.
->> - Every Crystron effect is a quick effect that triggers when the opponent activates something.
->> - The disruption is NOT a negate. It is the summon effect of whatever Synchro you just made.
->> - Trains give you free level 10 machine bodies to Synchro with, and a rank 10 Xyz win condition.
->> - Pure Crystron is 100% reactive. The Trains are what let you actually kill someone.
+> Why the two halves are together.
+>> - Pure Crystron is reactive. It disrupts on your opponent's turn and wins slowly or not at all.
+>> - Trains are proactive. They flood level 10 bodies and Xyz into rank 10 beaters and burn.
+>> - Crystron gives Trains opponent's-turn interaction. Trains give Crystron a way to close.
+>> - The glue is that Crystron's lock allows MACHINES, and every Train is an EARTH machine.
 
-## Part 1: The Crystron half.
+> The thing most write-ups get wrong.
+>> - The Crystron lock is not one lock. It is two, and only one of them permits Xyz.
+>> - Get this wrong and you build a rank 10 board that the game will not let you summon.
 
-> The core loop.
->> - 1 = Opponent activates a card or effect.
->> - 2 = Your Crystron tuner's quick effect triggers.
->> - 3 = Special summon a Crystron from the DECK.
->> - 4 = Immediately Synchro summon a MACHINE Synchro using monsters you control.
->> - 5 = That Synchro's on-summon effect is your disruption (banish, position change, ATK drop).
->> - 6 = Repeat for every tuner you are holding.
+## The lock problem. This is the whole deck.
 
-> Key main deck cards.
->> - Crystron Tristaros. Level 2 WATER machine tuner. The modern engine card, from Supreme Darkness.
->> - Tristaros quick effect: summon a Crystron from deck, then Synchro summon a machine Synchro.
->> - Tristaros grave effect: banish itself, destroy your own Synchro, summon 2 Crystrons from deck.
->> - Crystron Quan (Lv1), Crystron Rion (Lv2), Crystron Citree (Lv3). The older tuners.
->> - Crystron Sulfefnir. Level 5 non-tuner. Summons itself from hand OR grave, destroys a card.
->> - Crystron Inclusion. Spell. Searches any Crystron card, battle protection, revives from grave.
->> - Crystron Cluster. Continuous trap. Shuffle a Crystron from grave or banishment to destroy a card.
+> The two locks again, because it decides your entire turn.
+>> - Smiger, Thystvern, Prasiortle, Rosenix -> Machine SYNCHRO only. NO Xyz. NO Link.
+>> - Tristaros GY effect, Sulfador, Night Train Blue Traveler -> MACHINE monsters. Xyz IS allowed.
+>> - Tristaros's quick effect applies no lock at all.
 
-> Key extra deck cards.
->> - Crystron Ametrix. Level 5. Flips the opponent's special summoned monsters to defence.
->> - Crystron Eleskeletus. Level 7. Opponent's monsters lose 500 ATK/DEF. Recycles Crystrons.
->> - Crystron Quariongandrax. Needs 2+ TUNERS. Banishes from the opponent's field and grave.
->> - Crystron Phoenix. Accel Synchro. Revives ANY monster when destroyed, not just Crystrons.
+> What that forces you to do.
+>> - If your turn is going to end on rank 10, do NOT open with Smiger or Thystvern.
+>> - If your turn is going to end on Synchro disruption, Smiger is fine and is your best starter.
+>> - You are choosing between the two plans at the FIRST activation of the turn, not later.
+>> - This is the single most common way to brick yourself out of your own extra deck.
 
-> Everything floats.
->> - Ametrix, Eleskeletus, Quariongandrax and Phoenix all summon something when destroyed.
->> - This means removal trades badly against you.
->> - Do not be scared of your Synchros dying. That is the plan.
+## The Train package.
 
-## Part 2: Why Trains.
+> Night Train Blue Traveler. Level 10, 2500. Three copies. The real glue card.
+>> - Discard it -> add Revolving Switchyard or Train Connection from DECK OR GY.
+>> - ^ A discard that searches your field spell. This is why the deck is consistent at all.
+>> - GY effect: target another EARTH machine in your GY -> summon BOTH it and this card.
+>> - ^ Two level 10 bodies out of nowhere. That is a rank 10 on its own.
+>> - The revive effect is ONCE PER DUEL. Not per turn. Spend it deliberately.
+>> - It also locks you to MACHINE monsters, which is the permissive lock. Xyz still legal.
 
-> The problem Crystron has on its own.
->> - Tristaros LOCKS you into machine monsters from the extra deck for the rest of the turn.
->> - Crystron also has very few free bodies to Synchro WITH.
->> - So you need extenders that are machines and that do not eat your normal summon.
+> Heavy Freight Train Derricrane. Level 10, 2800.
+>> - Summons itself from hand when an EARTH machine is summoned to your field.
+>> - Its original ATK/DEF become HALVED when it does. It is a body, not a beater.
+>> - It has NO banish cost. That is a common misremembering.
+>> - Destroy effect: ONLY when it is detached from an Xyz monster to activate that monster's effect.
+>> - ^ So Gustav Max detaching Derricrane for its burn ALSO destroys a card. That is the combo.
 
-> Trains solve all three.
->> - Trains are EARTH machines, so they do not break the machine lock.
->> - Trains summon themselves for free out of the hand.
->> - Trains are level 10, which fixes the Synchro maths.
+> Heavy Armored Knight Babeldecker. Level 10, 500/3000.
+>> - Normal summon it WITHOUT tributing.
+>> - On summon: special summon 1 EARTH machine from your HAND.
+>> - Main Phase, if your opponent activated a card or effect this turn: Xyz summon a rank 10 EARTH
+>>   machine using ONLY this card as material.
+>> - ^ One body into a rank 10. Read the condition, it needs your opponent to have done something.
 
-> The Synchro maths.
->> - Level 10 + Tristaros (2) = Level 12.
->> - Level 10 + Quan (1) = Level 11.
->> - Level 10 + Citree (3) = Level 13.
->> - Crystron on its own cannot reach any of those numbers.
+> Scrap Recycler. Level 3, EARTH machine. Three copies.
+>> - On normal or special summon: send 1 MACHINE monster from deck to GY.
+>> - ^ Fuels Night Train Blue Traveler's revive, Sulfador, and the Schedule spells.
+>> - Also: shuffle 2 level 4 EARTH machines from GY into deck -> draw 1.
 
-> Key train cards.
->> - Heavy Freight Train Derricrane. Banish 1 card from grave, summon itself from hand.
->> - Derricrane also destroys a card when it is sent from the field to the grave.
->> - Super Express Bullet Train. Summons itself if you control an EARTH machine, then searches a level 10.
->> - Revolving Switchyard. The glue card. See below.
+> Flying Pegasus Railroad Stampede. Level 4, EARTH machine, 1800 ATK.
+>> - It is the card Revolving Switchyard summons. That is not a coincidence, it is the requirement.
+>> - On summon: revive an EARTH machine from GY in defence with effects negated.
+>> - It can also copy levels between itself and another monster you control.
 
-> Revolving Switchyard is the glue.
->> - Effect 1 = Send 1 card from hand to grave, add a level 10 EARTH machine from deck.
->> - ^ The "cost" is upside. You discard a Crystron that WANTED to be in the grave.
->> - Effect 2 = When a level 10 EARTH machine is summoned, summon a level 4 EARTH machine with 1800+ ATK from deck.
->> - ^ And that level 4 becomes level 10. That is an instant rank 10 Xyz.
+> The Schedule spells.
+>> - Exceptional Schedule. Add Special Schedule or Urgent Schedule from deck.
+>> - ^ Then you MAY give your opponent a level 10 / 3000 ATK Diagram Token.
+>> - ^ That looks insane. It is deliberate. See below.
+>> - Exceptional Schedule GY effect: send 1 card you control -> revive a level 10 machine.
+>> - Urgent Schedule. Requires YOUR OPPONENT TO CONTROL MORE MONSTERS THAN YOU.
+>> - ^ The Diagram Token you just gave them is how you turn that condition on.
+>> - Urgent Schedule then summons a level 4 or lower AND a level 5 or higher EARTH machine from deck.
 
-> The rank 10 payoff.
->> - Superdreadnought Rail Cannon Gustav Max. 2000 burn damage.
->> - Superdreadnought Rail Cannon Juggernaut Liebe. 3500 ATK.
->> - Number 81: Superdreadnought Rail Cannon Superior Dora.
->> - Divine Arsenal AA-ZEUS, off any Xyz summon.
+## Revolving Switchyard. Read the last line of the card.
 
-## Part 3: How a game plays.
+> It has two effects and you may only ever use ONE of them per turn.
+>> - "You can only use 1 Revolving Switchyard effect per turn, and only once that turn."
+>> - Treating these as a two-step combo is the most common error made about this deck.
 
-> Going first.
->> - 1 = Do NOT dump your whole hand. Hold your tuners.
->> - 2 = Set up a modest board. A couple of machine Synchros, or one rank 10.
->> - 3 = Get Crystrons INTO the grave. Switchyard's discard is the easiest way.
->> - 4 = Set Crystron Cluster. Keep Crystron Inclusion available.
->> - 5 = Pass with tuners still in hand.
->> - 6 = Every effect your opponent activates now risks turning on another Synchro summon.
+> Effect A, the search.
+>> - Send 1 card from your HAND to the GY -> add 1 level 10 EARTH machine from deck.
+>> - The send is upside. Pitch a Crystron that wanted to be in the GY anyway.
 
-> Going second.
->> - 1 = Trains give you the beatdown plan that pure Crystron does not have.
->> - 2 = Derricrane and Bullet Train summon themselves off almost nothing.
->> - 3 = Switchyard turns one level 10 into two bodies.
->> - 4 = Xyz into a rank 10, then AA-ZEUS to wipe the board.
+> Effect B, the summon.
+>> - Triggers when a level 10 EARTH machine is normal or special summoned to your field.
+>> - Summon 1 level 4 EARTH machine with 1800+ ATK from deck, and it BECOMES level 10.
+>> - ^ Instant rank 10 off a single level 10.
+>> - BUT: "your opponent takes no battle damage for the rest of this turn, even if this card leaves the field."
+>> - ^ You have just turned off your own kill. Do not use effect B on a turn you intend to attack for game.
 
-> Turn 2 and beyond.
->> - Convert the floaters left over from your opponent's turn into rank 10 pressure.
->> - Quariongandrax banishing from field AND grave is your best out to a resilient board.
+## The rank 10 payoff.
 
-## Part 4: Weaknesses.
+> Superdreadnought Rail Cannon Gustav Max. Rank 10, 3000. 2 level 10 monsters.
+>> - Once per turn: detach 1 -> 2000 damage.
+>> - Detach Derricrane specifically -> also destroy 1 card your opponent controls.
+
+> Superdreadnought Rail Cannon Gustav Rocket. Rank 10, 5000.
+>> - 3 level 10 monsters, OR discard 1 and use a Gustav Max you control, transferring its materials.
+>> - Quick effect with material: negate a monster effect -> destroy it -> 1000 damage.
+>> - End Phase: detach 1 or it destroys itself. It is not a permanent board.
+
+> Number 81: Superdreadnought Rail Cannon Super Dora. Rank 10, 3200/4000.
+>> - The name is SUPER Dora, not Superior Dora.
+>> - Quick effect: detach 1 -> 1 face-up monster becomes unaffected by card effects except its own.
+>> - Use it on your OWN threat to walk it through removal.
+
+> Superdreadnought Rail Cannon Flying Launcher. Rank 10, 3800.
+>> - On Xyz summon: add 1 EARTH machine or Barrage Blast from deck.
+>> - Grants an extra normal summon of a machine.
+>> - Detach any number -> destroy that many spells/traps.
+
+> Superdreadnought Rail Cannon Juggernaut Liebe. Rank 11, 4000. Not a rank 10.
+>> - Normally needs 3 level 11 monsters, which you will never do.
+>> - The real line: Xyz using 1 rank 10 MACHINE Xyz you control, transferring its materials.
+>> - Detach 1 -> gains 2000 ATK, but only it may attack this turn.
+>> - Attacks up to materials +1 times per Battle Phase. This is your actual kill.
+
+## How the lines run.
+
+These follow directly from the card text above. They are not copied from a tournament combo guide,
+so treat them as the shape of the deck rather than as an optimised list.
+
+> Opening for rank 10. Do not touch Smiger.
+>> 1. Night Train Blue Traveler, discard -> search Revolving Switchyard.
+>> 2. Activate Switchyard.
+>> 3. Summon any level 10 EARTH machine.
+>> 4. Switchyard effect B -> summon Flying Pegasus Railroad Stampede from deck, it becomes level 10.
+>> 5. Two level 10 monsters -> Xyz into Gustav Max.
+>> 6. REMEMBER: effect B means your opponent takes no battle damage this turn.
+
+> Opening for disruption instead.
+>> 1. Crystron Inclusion -> search a Crystron piece.
+>> 2. Smiger -> destroy a face-up card you control -> summon a Crystron Tuner from deck.
+>> 3. You are now locked to Machine Synchro. No Xyz this turn. Accept it.
+>> 4. Set up Synchros, keep Tristaros in hand for your opponent's turn.
+>> 5. Smiger from GY -> banish -> add Crystron Cluster.
+
+> The Diagram Token trick.
+>> 1. Exceptional Schedule -> add Urgent Schedule.
+>> 2. Give your opponent the level 10 / 3000 Diagram Token.
+>> 3. They now control more monsters than you, which is Urgent Schedule's activation condition.
+>> 4. Urgent Schedule -> summon a level 4 or lower and a level 5 or higher EARTH machine from deck.
+>> 5. You cannot attack with non-machines this turn. In this deck that costs you nothing.
+
+> Closing with Babeldecker on turn 2.
+>> 1. Your opponent activated something on their turn, so Babeldecker's condition is live.
+>> 2. Normal summon Babeldecker without tributing.
+>> 3. On summon -> special summon an EARTH machine from hand.
+>> 4. Babeldecker alone -> Xyz into a rank 10 EARTH machine.
+>> 5. Rank 10 -> Juggernaut Liebe using it as material, transferring materials.
+>> 6. Detach for +2000 ATK and multiple attacks.
+
+## The current build.
+
+> Roughly what the lists look like.
+>> - Trains: 3 Night Train Blue Traveler, 3 Scrap Recycler, 1 Derricrane, 1 Babeldecker, 1 Flying Pegasus.
+>> - Spells: 3 Exceptional Schedule, 2 Urgent Schedule, 1 Revolving Switchyard.
+>> - Crystron: 3 Inclusion, 2 Sulfador, 2 Sulfefnir, 1 Tristaros, 1 Citree, 1 Smiger, 1 Thystvern, 1 Cluster.
+>> - Hand traps and interaction: Ash, Maxx "C", Droll, Mulcharmy Fuwalos, Forbidden Droplet, Triple Tactics Talent.
+>> - Extra deck: the five Rail Cannons, Eleskeletus x2, Quariongandrax, plus machine Links.
+
+> Things the deck does NOT play, despite what you might expect.
+>> - Super Express Bullet Train. It needs ALL your monsters to be EARTH machines, and yours are not.
+>> - ^ It also does not search. Its second effect is an End Phase GY effect that recovers a machine.
+>> - The older Crystron Tuners. Quan and Rion are too slow. Tristaros and Citree carry the engine.
+
+## Weaknesses.
 
 > What blows this deck out.
->> - A patient opponent. If they do not activate effects, your quick effects never turn on.
->> - Anything that stops special summoning. Your disruption IS a summon.
->> - Nibiru, the Primal Being. The rank 10 lines walk straight into it.
->> - The machine lock. No S:P Little Knight, no Apollousa, no generic extra deck outs.
+>> - Nibiru, the Primal Being. Every rank 10 line summons a lot of bodies.
+>> - Anything that stops special summoning, on both halves of the deck.
+>> - Droll & Lock Bird. Night Train, Exceptional Schedule, Switchyard and Inclusion are all searches.
+>> - Your own misplay of the lock. Opening Smiger and then wanting Xyz is a self-inflicted loss.
 
 > What it survives.
->> - Most single hand traps only eat one link of a redundant chain.
->> - The deck is resilient rather than explosive. It grinds. It does not blow people out.
+>> - Single hand traps, usually. There is a lot of redundancy across three Night Trains and three Recyclers.
+>> - Removal, because the Crystron half floats and the Train half revives out of the GY.
 
 > Honest rating.
->> - Rogue deck. Fun and cool, not top tier.
->> - Crystron Halqifibrax shares the name but is FORBIDDEN in Master Duel. It is not part of this deck.
-
-## Notes.
-
-> Sources.
->> - https://www.masterduelmeta.com/tier-list/deck-types/Crystron%20Trains
->> - https://www.masterduelmeta.com/articles/guides/crystron-dlf2p
->> - https://ygoprodeck.com/article/5-new-crystron-cards-302499
->> - https://ygorganization.com/noturtlesynchro/
-
-> TODO.
->> - Write out the exact step-by-step combo lines, in the same style as the Maliss page.
->> - Decide on the Crystron vs Crystron Trains split. Pure Crystron is a different tier list entry.
+>> - Rogue. More proactive than pure Crystron and more fragile than a real tier deck.
+>> - It plays a huge number of one-ofs, so it draws unevenly. Some hands do nothing.

--- a/Writerside/topics/Master-duel/Crystron-trains.md
+++ b/Writerside/topics/Master-duel/Crystron-trains.md
@@ -1,0 +1,126 @@
+# Crystron Trains
+
+Crystron is the engine. Trains are the fuel and the win condition.
+
+## The short version.
+
+> What the deck actually does.
+>> - Crystron Synchro summons on your OPPONENT'S turn, not yours.
+>> - Every Crystron effect is a quick effect that triggers when the opponent activates something.
+>> - The disruption is NOT a negate. It is the summon effect of whatever Synchro you just made.
+>> - Trains give you free level 10 machine bodies to Synchro with, and a rank 10 Xyz win condition.
+>> - Pure Crystron is 100% reactive. The Trains are what let you actually kill someone.
+
+## Part 1: The Crystron half.
+
+> The core loop.
+>> - 1 = Opponent activates a card or effect.
+>> - 2 = Your Crystron tuner's quick effect triggers.
+>> - 3 = Special summon a Crystron from the DECK.
+>> - 4 = Immediately Synchro summon a MACHINE Synchro using monsters you control.
+>> - 5 = That Synchro's on-summon effect is your disruption (banish, position change, ATK drop).
+>> - 6 = Repeat for every tuner you are holding.
+
+> Key main deck cards.
+>> - Crystron Tristaros. Level 2 WATER machine tuner. The modern engine card, from Supreme Darkness.
+>> - Tristaros quick effect: summon a Crystron from deck, then Synchro summon a machine Synchro.
+>> - Tristaros grave effect: banish itself, destroy your own Synchro, summon 2 Crystrons from deck.
+>> - Crystron Quan (Lv1), Crystron Rion (Lv2), Crystron Citree (Lv3). The older tuners.
+>> - Crystron Sulfefnir. Level 5 non-tuner. Summons itself from hand OR grave, destroys a card.
+>> - Crystron Inclusion. Spell. Searches any Crystron card, battle protection, revives from grave.
+>> - Crystron Cluster. Continuous trap. Shuffle a Crystron from grave or banishment to destroy a card.
+
+> Key extra deck cards.
+>> - Crystron Ametrix. Level 5. Flips the opponent's special summoned monsters to defence.
+>> - Crystron Eleskeletus. Level 7. Opponent's monsters lose 500 ATK/DEF. Recycles Crystrons.
+>> - Crystron Quariongandrax. Needs 2+ TUNERS. Banishes from the opponent's field and grave.
+>> - Crystron Phoenix. Accel Synchro. Revives ANY monster when destroyed, not just Crystrons.
+
+> Everything floats.
+>> - Ametrix, Eleskeletus, Quariongandrax and Phoenix all summon something when destroyed.
+>> - This means removal trades badly against you.
+>> - Do not be scared of your Synchros dying. That is the plan.
+
+## Part 2: Why Trains.
+
+> The problem Crystron has on its own.
+>> - Tristaros LOCKS you into machine monsters from the extra deck for the rest of the turn.
+>> - Crystron also has very few free bodies to Synchro WITH.
+>> - So you need extenders that are machines and that do not eat your normal summon.
+
+> Trains solve all three.
+>> - Trains are EARTH machines, so they do not break the machine lock.
+>> - Trains summon themselves for free out of the hand.
+>> - Trains are level 10, which fixes the Synchro maths.
+
+> The Synchro maths.
+>> - Level 10 + Tristaros (2) = Level 12.
+>> - Level 10 + Quan (1) = Level 11.
+>> - Level 10 + Citree (3) = Level 13.
+>> - Crystron on its own cannot reach any of those numbers.
+
+> Key train cards.
+>> - Heavy Freight Train Derricrane. Banish 1 card from grave, summon itself from hand.
+>> - Derricrane also destroys a card when it is sent from the field to the grave.
+>> - Super Express Bullet Train. Summons itself if you control an EARTH machine, then searches a level 10.
+>> - Revolving Switchyard. The glue card. See below.
+
+> Revolving Switchyard is the glue.
+>> - Effect 1 = Send 1 card from hand to grave, add a level 10 EARTH machine from deck.
+>> - ^ The "cost" is upside. You discard a Crystron that WANTED to be in the grave.
+>> - Effect 2 = When a level 10 EARTH machine is summoned, summon a level 4 EARTH machine with 1800+ ATK from deck.
+>> - ^ And that level 4 becomes level 10. That is an instant rank 10 Xyz.
+
+> The rank 10 payoff.
+>> - Superdreadnought Rail Cannon Gustav Max. 2000 burn damage.
+>> - Superdreadnought Rail Cannon Juggernaut Liebe. 3500 ATK.
+>> - Number 81: Superdreadnought Rail Cannon Superior Dora.
+>> - Divine Arsenal AA-ZEUS, off any Xyz summon.
+
+## Part 3: How a game plays.
+
+> Going first.
+>> - 1 = Do NOT dump your whole hand. Hold your tuners.
+>> - 2 = Set up a modest board. A couple of machine Synchros, or one rank 10.
+>> - 3 = Get Crystrons INTO the grave. Switchyard's discard is the easiest way.
+>> - 4 = Set Crystron Cluster. Keep Crystron Inclusion available.
+>> - 5 = Pass with tuners still in hand.
+>> - 6 = Every effect your opponent activates now risks turning on another Synchro summon.
+
+> Going second.
+>> - 1 = Trains give you the beatdown plan that pure Crystron does not have.
+>> - 2 = Derricrane and Bullet Train summon themselves off almost nothing.
+>> - 3 = Switchyard turns one level 10 into two bodies.
+>> - 4 = Xyz into a rank 10, then AA-ZEUS to wipe the board.
+
+> Turn 2 and beyond.
+>> - Convert the floaters left over from your opponent's turn into rank 10 pressure.
+>> - Quariongandrax banishing from field AND grave is your best out to a resilient board.
+
+## Part 4: Weaknesses.
+
+> What blows this deck out.
+>> - A patient opponent. If they do not activate effects, your quick effects never turn on.
+>> - Anything that stops special summoning. Your disruption IS a summon.
+>> - Nibiru, the Primal Being. The rank 10 lines walk straight into it.
+>> - The machine lock. No S:P Little Knight, no Apollousa, no generic extra deck outs.
+
+> What it survives.
+>> - Most single hand traps only eat one link of a redundant chain.
+>> - The deck is resilient rather than explosive. It grinds. It does not blow people out.
+
+> Honest rating.
+>> - Rogue deck. Fun and cool, not top tier.
+>> - Crystron Halqifibrax shares the name but is FORBIDDEN in Master Duel. It is not part of this deck.
+
+## Notes.
+
+> Sources.
+>> - https://www.masterduelmeta.com/tier-list/deck-types/Crystron%20Trains
+>> - https://www.masterduelmeta.com/articles/guides/crystron-dlf2p
+>> - https://ygoprodeck.com/article/5-new-crystron-cards-302499
+>> - https://ygorganization.com/noturtlesynchro/
+
+> TODO.
+>> - Write out the exact step-by-step combo lines, in the same style as the Maliss page.
+>> - Decide on the Crystron vs Crystron Trains split. Pure Crystron is a different tier list entry.

--- a/Writerside/topics/Master-duel/Crystron.md
+++ b/Writerside/topics/Master-duel/Crystron.md
@@ -1,0 +1,155 @@
+# Crystron
+
+WATER machines that Synchro summon on your OPPONENT'S turn.
+
+Card text on this page checked against the card database on 2026-08-09.
+
+## The short version.
+
+> What the deck actually does.
+>> - Crystron Synchro summons during your opponent's turn, not yours.
+>> - The disruption is NOT a negate. It is the on-summon effect of whatever Synchro you just made.
+>> - You pass with a small board and cards still in hand. That is correct, not a failed combo.
+>> - Almost every Crystron effect destroys your OWN card as a cost. The deck is built to eat itself.
+>> - In exchange, nearly everything floats into something else.
+
+> The two halves you must not confuse.
+>> - The non-Tuners SET UP. They destroy your own card -> summon a Tuner from deck.
+>> - The Tuners PAY OFF. They summon a body on your opponent's turn -> immediately Synchro.
+>> - Tristaros is the modern card and does both jobs better than the originals.
+
+## The lock. Read this before anything else.
+
+> There are TWO different locks and they are not the same.
+>> - Smiger, Thystvern, Prasiortle and Rosenix lock you to Machine SYNCHRO monsters.
+>> - Tristaros's GY effect and Sulfador lock you to MACHINE monsters, Synchro or not.
+>> - The difference matters enormously. Machine Synchro only means NO Xyz and NO Link.
+>> - So the moment you use Smiger, rank 10 Xyz is off the table for the rest of the turn.
+
+> What this means in practice.
+>> - Tristaros's QUICK effect carries no lock at all. Only its GY effect does.
+>> - A line that never touches Smiger, Thystvern, Prasiortle, Rosenix or Sulfador is unlocked.
+>> - That is why the current lists still play S:P Little Knight and Baronne de Fleur.
+>> - "Crystron cannot use generic extra deck cards" is FALSE. It depends which starter you used.
+
+## The Tuners.
+
+> Crystron Tristaros. Level 2. The card that made the deck playable.
+>> - Quick effect, when your opponent activates a card or effect.
+>> - Special summon 1 Crystron from your DECK, then immediately Synchro summon 1 Machine Synchro.
+>> - It uses "monsters you control, including that monster", so it can eat your whole board.
+>> - GY effect: banish it -> destroy 1 of your Synchros -> summon 2 Crystrons from deck.
+>> - ^ THIS is the effect that applies the machine lock, and it is the one that refuels you.
+>> - Once per turn each.
+
+> The original three. Weaker, narrower, still played in ones.
+>> - All three work during your opponent's Main Phase or Battle Phase.
+>> - All three summon a non-Tuner with its effects NEGATED, then Synchro using ONLY those two.
+>> - ^ "Only that monster and this card" means exactly 2 materials. No extra bodies.
+>> - Crystron Quan. Level 1. Summons the non-Tuner from your HAND.
+>> - Crystron Citree. Level 2. Summons the non-Tuner from your GY. Materials are BANISHED after.
+>> - Crystron Rion. Level 3. Summons the non-Tuner from your BANISHMENT. Materials go to DECK.
+
+> Do not misremember the levels.
+>> - Quan is 1. Citree is 2. Rion is 3. Tristaros is 2.
+>> - Citree and Rion get mixed up constantly. Check before you do Synchro maths.
+
+## The non-Tuner starters.
+
+> All four share the same first effect, word for word.
+>> - Target 1 face-up card YOU control -> destroy it -> summon 1 Crystron Tuner from deck.
+>> - Applies the Machine SYNCHRO lock for the rest of the turn.
+>> - Only 1 effect per turn each, and only once that turn.
+
+> They differ only in the GY effect.
+>> - Crystron Smiger (Lv3). Banish from GY -> add 1 Crystron SPELL/TRAP from deck.
+>> - Crystron Thystvern (Lv3). Banish from GY -> add 1 Crystron MONSTER from deck.
+>> - Crystron Prasiortle (Lv2). Banish from GY -> summon 1 Crystron from your HAND.
+>> - Crystron Rosenix (Lv4). Banish from GY -> summon a Crystron Token (Lv1, 0 ATK, cannot be Tributed).
+
+> The Sulf pair. These are your level 5 bodies.
+>> - Crystron Sulfefnir (Lv5). Discard a Crystron -> summon itself in DEFENCE -> destroy 1 card YOU control.
+>> - ^ It destroys YOUR card, not the opponent's. That is the cost, and it triggers your floats.
+>> - Sulfefnir also floats: destroyed on field -> summon a Crystron from deck in defence.
+>> - Crystron Sulfador (Lv5). Destroy 1 Crystron card you control -> summon itself. Locks to MACHINE.
+>> - Sulfador on summon: send up to 2 differently named Crystron cards from deck to GY.
+>> - ^ That is the best single piece of setup in the deck. It loads the GY for everything else.
+
+## The Synchro line.
+
+> Crystron Ametrix. Level 5.
+>> - On Synchro summon: change ALL face-up special summoned monsters your opponent controls to defence.
+>> - Destroyed: summon 1 non-Synchro Crystron from your GY.
+
+> Crystron Eleskeletus. Level 7.
+>> - Continuous: all monsters your opponent controls lose 500 ATK/DEF.
+>> - On Synchro summon: add 1 Crystron card from GY OR banishment to hand.
+>> - Destroyed: summon 1 Crystron from GY or banishment.
+>> - The most played Synchro in the deck. Lists run two.
+
+> Crystron Quariongandrax. Level 9. Needs 2+ TUNERS plus 1 non-Tuner.
+>> - On Synchro summon: banish opponent monsters on FIELD and in GY, up to the material count.
+>> - ^ Banishing from the grave is your best answer to a resilient board.
+>> - Destroyed: summon 1 banished monster, ANY monster, not just yours originally.
+
+> Crystron Quandax. Level 4 Synchro TUNER. Do not skip this card.
+>> - Once per Chain, on your opponent's turn (Quick Effect): immediately Synchro summon again, using itself.
+>> - It is how you climb mid-chain, and it is the ONLY way to reach Phoenix.
+>> - Destroyed: summon 1 non-Synchro Crystron from your GY.
+
+> Crystron Phoenix. Level 9. Requires 1 Tuner SYNCHRO + 1+ non-Tuner SYNCHRO.
+>> - ^ Read the materials. You need Quandax on the field. You cannot make this from main deck monsters.
+>> - On Synchro summon: banish ALL spells and traps your opponent controls AND in their GY.
+>> - ^ That is the single strongest effect in the archetype and it is easy to forget it exists.
+>> - Destroyed: summon 1 other monster from your GY.
+
+## Everything floats.
+
+> The whole deck is built to be destroyed.
+>> - Ametrix, Eleskeletus, Quariongandrax, Quandax and Phoenix all summon something when destroyed.
+>> - Sulfefnir floats when destroyed on the field.
+>> - So removal trades BADLY against you.
+>> - Do not play around your own Synchros dying. Dying is the plan.
+>> - Note the trigger wording: destroyed by BATTLE OR CARD EFFECT. Banishing them dodges all of it.
+
+## Spells and traps.
+
+> Crystron Inclusion. Continuous spell. The best single starter in the deck.
+>> - On activation: add 1 Crystron card from deck (not another Inclusion).
+>> - Continuous: the first time each Crystron you control would be destroyed BY BATTLE each turn, it survives.
+>> - Banish from GY -> revive 1 Crystron from your GY.
+>> - Only 1 Inclusion activation per turn. Current lists run three copies anyway.
+
+> Crystron Cluster. Continuous trap.
+>> - Your Crystron cards cannot be BANISHED by your opponent's effects. This is real protection.
+>> - Shuffle a Crystron from GY or banishment into the deck -> destroy 1 face-up card.
+>> - Destroy 2 instead if you control a Crystron Synchro.
+
+> Crystron Impact and Crystron Entry. Older traps, situational.
+>> - Impact: revive a banished Crystron, set opponent monsters' DEF to 0. GY effect negates a targeting effect.
+>> - Entry: summon 2 Crystron Tuners, 1 from hand and 1 from GY. GY effect changes a Crystron's level.
+
+## The current build.
+
+> Modern lists are a WATER pile, not a pure Crystron deck.
+>> - Roughly: 2 Tristaros, 3 Smiger, 3 Sulfador, 3 Inclusion, 1 each Citree, Thystvern, Sulfefnir, Cluster.
+>> - Then an Icejade package (Aegirine, Cradle, Tremora, Ran Aegirine) as WATER extenders.
+>> - Then hand traps. Ash, Maxx "C", Droll, Mulcharmy Fuwalos, Dominus Impulse.
+>> - Extra deck runs Eleskeletus x2, Quariongandrax, plus generic Synchro and Link outs.
+>> - The Trains variant is a different deck entirely. See [Crystron Trains](Crystron-trains.md).
+
+## Weaknesses.
+
+> What blows this deck out.
+>> - A patient opponent. If they never activate anything, your Tuners never turn on.
+>> - Anything that stops special summoning. Your entire disruption IS a summon.
+>> - Banishing removal. Your floats need DESTRUCTION to trigger. Cluster only protects Crystron cards.
+>> - Droll & Lock Bird, because Thystvern, Smiger and Inclusion are all searches.
+
+> What it survives.
+>> - Single hand traps usually eat one link of a redundant chain, not the whole turn.
+>> - The deck grinds. It does not blow people out, and it does not fold to one interruption.
+
+> Honest rating.
+>> - Rogue. Genuinely fun, genuinely not top tier.
+>> - Crystron Halqifibrax shares the name and is FORBIDDEN in Master Duel. It is not part of this deck.


### PR DESCRIPTION
Adds two deck pages to the Master Duel section and registers both in `mi.tree`.

- `Writerside/topics/Master-duel/Crystron.md` — the engine: opponent's-turn Synchro summoning, the tuners and what each actually summons, the Synchro line-up, and the two separate Extra Deck locks.
- `Writerside/topics/Master-duel/Crystron-trains.md` — the Train package bolted on top: level 10 EARTH machine bodies, Revolving Switchyard, and the rank 10 Xyz plan.

## History of this branch

The first commit (`1054d7a`) was written in an environment where every card database was blocked by the egress proxy, so its card text was paraphrased from search snippets and roughly a dozen claims were wrong — some inverting the advice. The second commit (`e5e259d`) rewrote both pages against real card text and split the single page in two, matching how masterduelmeta lists Crystron and Crystron Trains as separate deck types. See the [comment on this PR](https://github.com/LewisIsWorking/PathWarsWiki/pull/54#issuecomment-5230311893) for the full list of corrections.

Only the corrected second commit's content is being proposed for merge; the first commit is kept for history.

## Style

Follows the existing Master Duel pages (`Maliss-in-underground.md`, `Memento.md`): `> Header.` / `>> - item.` blockquote lists, short declarative lines.

## Known gap

Neither page carries numbered tournament combo lines like the Maliss page does — those could not be sourced. The combo sections present are derived from verified card text and are labelled as such on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y91VfwYGJNpuQwSaN9QYw4