### PR TITLE
[proud-cormorant] fix(ci): sparse-checkout cone mode cannot select a file

### DIFF
--- a/.github/workflows/sync-pbp-transcripts.yml
+++ b/.github/workflows/sync-pbp-transcripts.yml
@@ -54,8 +54,13 @@ jobs:
             https://github.com/LewisIsWorking/telegram-pbp-reminder.git \
             /tmp/botrepo
           cd /tmp/botrepo
-          git sparse-checkout set data/pbp_logs config.json
+          # --no-cone because cone mode treats every argument as a
+          # DIRECTORY, and config.json is a file: cone mode fails with
+          # "'config.json' is not a directory". Found by running this
+          # workflow rather than by reading it.
+          git sparse-checkout set --no-cone /data/pbp_logs/ /config.json
           test -d data/pbp_logs || { echo "archive missing"; exit 1; }
+          test -f config.json  || { echo "config missing";  exit 1; }
 
       - name: Publish into the wiki
         run: |


### PR DESCRIPTION
First real run of the sync workflow failed:

```
fatal: 'config.json' is not a directory; to treat it as a directory anyway,
rerun with --skip-checks
```

`git sparse-checkout set` defaults to **cone mode**, which treats every argument as a directory prefix. The sync needs one directory (`data/pbp_logs`) and one file (`config.json`), so it needs `--no-cone` with leading-slash patterns.

Caught by **triggering the workflow**, not by reading it. No test could have found this — it is a property of the runner, not the code.

Also now asserts `config.json` actually arrived. The original check tested only the archive directory, so a missing config would have passed here and failed further along with a worse message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZ8XyuCnMxx1duFhoX4ZP