### PR TITLE
[proud-cormorant] fix(C07): Nikk-Nakk, not Nikk-Nikk

### DIFF
--- a/Writerside/topics/C07-The-Hopeful-End-Times/C07-Story1-Combat-Scrapyard.md
+++ b/Writerside/topics/C07-The-Hopeful-End-Times/C07-Story1-Combat-Scrapyard.md
@@ -2,7 +2,7 @@
 
 > COMBAT.
 >> 1. Encounter name: Scrapyard of Cursed Metal and Metal Slime!.
->> 2. Encounter location: Nikk-Nikk's scrapyard.
+>> 2. Encounter location: Nikk-Nakk's scrapyard.
 >> 3. Encounter started = 2026 July 7th at 06:47am.
 >> 4. Round 1!
 


### PR DESCRIPTION
Counted across every source that holds the name:

| | Nikk-Nakk | Nikk-Nikk | Nik-Nak / Nik Nak |
|---|---:|---:|---:|
| transcripts | **32** | 2 | 2 |
| GM wiki | **24** | 0 | 0 |
| player wiki | 0 | **1** (this file) | 0 |

**56 of 60 uses are `Nikk-Nakk`**, and the GM docs — the authored source, rather than fast typing in a live thread — use it exclusively. The four variants are mid-session slips.

Only this page is corrected. The transcripts keep their typos: they are a record of what was actually posted, and their wiki copies are generated from the bot's archive, so an edit there would be overwritten on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZ8XyuCnMxx1duFhoX4ZP