### PR TITLE
[proud-cormorant] docs(rules): show the actual distributions, and Anthony's point

### DIFF
--- a/Writerside/topics/Extra-rules/Hero-Point-Rerolls.md
+++ b/Writerside/topics/Extra-rules/Hero-Point-Rerolls.md
@@ -19,8 +19,34 @@ A reroll of 1 gives 11. A 9 gives 19. **A 10 gives 20.** Anything 11 or higher i
 - The average contribution is **15.5**. If your die showed less than that, a reroll expects to beat it — including rerolling a mediocre *success* to reach for a critical.
 
 > ⚠️ **But you can still critically fail.** Our variant adds **+10 to the total**; it does not change the number on the die. A natural 1 is still a natural 1, and a natural 1 still drops you one degree of success. That is a flat **5% of rerolls**, and it is the one weakness our rule has.
->
+>> How bad that is depends on the check. A natural 1 gives you 11 with a face of 1, so:
+>> - needing **11 or less** → the +10 got you to a success, the natural 1 knocks it back to a **failure**
+>> - needing **12 or more** → **critical failure**
+
 > ⚠️ The same quirk cuts the other way: a rerolled **10** contributes 20, but the die still shows 10 — so it does **not** count as a natural 20 and does **not** upgrade you to a critical success.
+
+---
+
+## What the dice actually do
+
+Our rule catches **10 or lower**, which surprises people — it sounds like "under 10". So a rerolled 10 gets the +10 as well and lands on 20.
+
+| Reroll shows | Contributes | How often |
+|---|---|---|
+| 1 | 11 | 5% — **and it is still a natural 1** |
+| 2–9 | 12–19 | 5% each |
+| 10 | **20** | 5% — but the face is 10, so **no** critical |
+| 11–19 | 11–19 | 5% each |
+| 20 | 20 | 5% — natural 20, upgrades a degree |
+
+Collapsed, that is **every value from 11 to 20 at 10% each**, with two hidden halves: half the 11s are natural 1s, and half the 20s are natural 20s.
+
+For comparison, the "set the die to 10" variant looks like this:
+
+| Reroll shows | Contributes | How often |
+|---|---|---|
+| 1–10 | 10 | **50%** |
+| 11–20 | 11–20 | 5% each |
 
 ---
 
@@ -74,6 +100,20 @@ Two results worth knowing:
 >> What it does do is stop things getting *worse*: it can never land below your original, so it protects you from turning a failure into a critical failure. That is comfort, not power.
 
 Ours is the only one that both removes almost all of the downside **and** keeps scaling on hard checks.
+
+### The honest case for the other one
+
+> Credit to **Anthony**, who worked the percentages out independently and made a point worth keeping.
+
+> **"Set the die to 10" respects a normal d20's odds more.**
+
+| Result | Normal d20 | Set-die-to-10 | Ours |
+|---|---|---|---|
+| any of 11–20 | 5% each | **5% each** | 10% each |
+
+Above 10 the "set the die" variant is **exactly a normal d20** — it only squashes the bottom half onto a single value and leaves everything else alone. Ours reshapes the whole distribution and doubles every result from 11 up.
+
+So it is a smaller intervention: *a d20 that cannot roll low*, rather than *a different die*. Add its **0% critical failures** against our 3.2%, and there is a real argument for it — just not an argument that it is stronger.
 
 ---
 


### PR DESCRIPTION
Anthony worked the percentages out independently in chat. He got **Galactic exactly right**, and he independently spotted the **natural-1 problem** — the thing I originally got wrong and had to correct.

He had one error, and it is the same one I made before reading the module source:

> `5%: 10`

**There is no 10.** The trigger is `result <= 10`, so a rerolled 10 gets the +10 as well and lands on **20**. That 5% belongs at 20. The rule *sounds* like "under 10" and isn't.

## Added to the page

**Both distributions in full**, face by face, so the shape is visible rather than described:

| Reroll shows | Contributes | How often |
|---|---|---|
| 1 | 11 | 5% — **still a natural 1** |
| 2–9 | 12–19 | 5% each |
| 10 | **20** | 5% — face is 10, so **no** crit |
| 11–19 | 11–19 | 5% each |
| 20 | 20 | 5% — natural 20, upgrades |

Collapsed: every value **11–20 at 10% each**, with two hidden halves — half the 11s are natural 1s, half the 20s are natural 20s.

**The natural-1 nuance quantified.** Anthony hedged with *"maybe not crit fail but still fail"*, and the hedge is exactly right:

- needing **11 or less** → just a **failure**
- needing **12 or more** → **critical failure**

**His second point, credited.** *"Galactic respects the dice normal percentages more."*

| Result | Normal d20 | Set-die-to-10 | Ours |
|---|---|---|---|
| any of 11–20 | 5% each | **5% each** | 10% each |

Above 10 the set-die variant **is** a normal d20. Ours doubles every value. So it's the smaller intervention — *a d20 that cannot roll low*, rather than *a different die* — and it has **0%** critical failures against our 3.2%.

A real argument for it. Just not an argument that it's stronger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZ8XyuCnMxx1duFhoX4ZP
